### PR TITLE
Add tests for SquareName0x88.fromBoard0x88number

### DIFF
--- a/src/test/java/com/spamalot/chess/board/SquareNameFromNumberTest.java
+++ b/src/test/java/com/spamalot/chess/board/SquareNameFromNumberTest.java
@@ -1,0 +1,27 @@
+package com.spamalot.chess.board;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.spamalot.chess.lib0x88.SquareName0x88;
+
+/**
+ * Tests for converting a 0x88 square number to a square name.
+ */
+@SuppressWarnings("static-method")
+public class SquareNameFromNumberTest {
+
+  /** Test that a valid square number returns the correct name. */
+  @Test
+  public void testValidSquare() {
+    assertEquals("b2", SquareName0x88.fromBoard0x88number(17));
+  }
+
+  /** Test that an invalid square number returns null. */
+  @Test
+  public void testInvalidSquare() {
+    assertNull(SquareName0x88.fromBoard0x88number(0x80));
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated test for converting 0x88 square numbers to names

## Testing
- `mvn test` *(fails: PluginResolutionException - unable to resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68438539e1688331955079a8438b452f